### PR TITLE
Add list cmd

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -15,24 +15,13 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
 // addCmd represents the add command
 var addCmd = &cobra.Command{
 	Use:   "add",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("add called")
-	},
+	Short: "Add key/value to the default locale file",
 }
 
 func init() {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,0 +1,50 @@
+// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// listCmd represents the list command
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("list called")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(listCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// listCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// listCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/locales.go
+++ b/cmd/locales.go
@@ -15,25 +15,31 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
-// listCmd represents the list command
-var listCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List current key/values and locales",
+// localesCmd represents the locales command
+var localesCmd = &cobra.Command{
+	Use:   "locales",
+	Short: "Lists locales in use",
+	Run: func(cmd *cobra.Command, args []string) {
+		// this will list the locales that are currently in use
+		fmt.Println("* en-US")
+	},
 }
 
 func init() {
-	rootCmd.AddCommand(listCmd)
+	listCmd.AddCommand(localesCmd)
 
 	// Here you will define your flags and configuration settings.
 
 	// Cobra supports Persistent Flags which will work for this command
 	// and all subcommands, e.g.:
-	// listCmd.PersistentFlags().String("foo", "", "A help for foo")
+	// localesCmd.PersistentFlags().String("foo", "", "A help for foo")
 
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
-	// listCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	// localesCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/values.go
+++ b/cmd/values.go
@@ -33,7 +33,7 @@ var valuesCmd = &cobra.Command{
 		// open file
 		content, err := ioutil.ReadFile("en-US.json")
 		if err != nil {
-			log.Fatalf("error reading file: %v", err)
+			log.Fatalf("%v", err)
 		}
 
 		// get JSON

--- a/cmd/values.go
+++ b/cmd/values.go
@@ -1,0 +1,74 @@
+// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	"io/ioutil"
+	"log"
+	"strings"
+)
+
+// valuesCmd represents the values command
+var valuesCmd = &cobra.Command{
+	Use:   "values",
+	Short: "List current key/values",
+	Run: func(cmd *cobra.Command, args []string) {
+		var data map[string]interface{}
+
+		// open file
+		content, err := ioutil.ReadFile("en-US.json")
+		if err != nil {
+			log.Fatalf("error reading file: %v", err)
+		}
+
+		// get JSON
+		if err := json.Unmarshal(content, &data); err != nil {
+			log.Fatalf("error unmarshalling JSON: %v", err)
+		}
+
+		// iterate over values, display
+		maxLen := 0
+		for key := range data {
+			if len(key) > maxLen {
+				maxLen = len(key)
+			}
+		}
+
+		for key, val := range data {
+			k := key + ": "
+			if len(key) < maxLen {
+				k = key + ": " + strings.Repeat(" ", maxLen-len(key))
+			}
+			fmt.Printf("%s \"%s\"\n", k, val)
+		}
+	},
+}
+
+func init() {
+	listCmd.AddCommand(valuesCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// valuesCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// valuesCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}


### PR DESCRIPTION
This PR adds the `list` command for `values` to list the key/values of the default `i18n` file.

A placeholder was also added to list the localization files, currently listing the default `en-US` file.